### PR TITLE
kumo-manager の lost node warning 時に ID がバイナリコードで出力されてるのを修正

### DIFF
--- a/src/logic/manager/framework.cc
+++ b/src/logic/manager/framework.cc
@@ -94,7 +94,7 @@ void framework::new_node(address addr, role_type id, shared_node n)
 
 void framework::lost_node(address addr, role_type id)
 {
-	LOG_WARN("lost node ",id," ",addr);
+	LOG_WARN("lost node ",(uint16_t)id," ",addr);
 	if(id == ROLE_MANAGER) {
 		return;
 


### PR DESCRIPTION
kumo-manager の lost node warning 時に ID がバイナリコードで出力されてるのを修正
