### PR TITLE
attach, detach 時に出力される余計な warning を削除

### DIFF
--- a/src/logic/server/mod_replace.cc
+++ b/src/logic/server/mod_replace.cc
@@ -287,10 +287,7 @@ void mod_replace_t::for_each_replace_copy::operator() (Storage::iterator& kv)
 	}
 
 	// FIXME 再配置中にServerがダウンしたときコピーが正常に行われないかもしれない？
-	if(current_owners.empty() || current_owners.front() != self) {
-		LOG_WARN("current_owners.empty() || current_owners.front() != self");
-		return;
-	}
+	if(current_owners.empty() || current_owners.front() != self) { return; }
 	//if(std::find(current_owners.begin(), current_owners.end(), self)
 	//		== current_owners.end()) { return; }
 


### PR DESCRIPTION
attach, detach 時に kumo-server が大量の warning を出力します。

```
2011-05-14 22:40:04 server/mod_replace.cc:291: current_owners.empty() || current_owners.front() != self
```

server/mod_replace の該当箇所を見ると、自ノードが保持しているデータのうち、自ノードがプライマリノードでないデータについて出力しているように見えます。
この warning を出す意図はわからなかったのですが、出力しないように修正しました。
