### PR TITLE
m_stream_core を accept用と connect用に分離

### DIFF
--- a/src/logic/server.proto.h
+++ b/src/logic/server.proto.h
@@ -322,7 +322,8 @@ private:
 	void stream_accepted(int fd, int err);
 	void stream_connected(int fd, int err);
 
-	std::auto_ptr<mp::wavy::core> m_stream_core;
+	std::auto_ptr<mp::wavy::core> m_stream_core_a; // for accept
+	std::auto_ptr<mp::wavy::core> m_stream_core_c; // for connect
 	class stream_handler;
 	friend class stream_handler;
 @end

--- a/src/logic/server/mod_replace_stream.cc
+++ b/src/logic/server/mod_replace_stream.cc
@@ -40,17 +40,20 @@ mod_replace_stream_t::~mod_replace_stream_t() { }
 
 void mod_replace_stream_t::init_stream(int fd)
 {
-	m_stream_core.reset(new mp::wavy::core());
+	m_stream_core_a.reset(new mp::wavy::core());
+	m_stream_core_c.reset(new mp::wavy::core());
 	using namespace mp::placeholders;
-	m_stream_core->listen(fd, mp::bind(
+	m_stream_core_a->listen(fd, mp::bind(
 				&mod_replace_stream_t::stream_accepted, this,
 				_1, _2));
-	m_stream_core->add_thread(2);  // FIXME 2
+	m_stream_core_a->add_thread(2);  // FIXME 2
+	m_stream_core_c->add_thread(2);  // FIXME 2
 }
 
 void mod_replace_stream_t::stop_stream()
 {
-	m_stream_core->end();
+	m_stream_core_a->end();
+	m_stream_core_c->end();
 }
 
 class mod_replace_stream_t::stream_accumulator {
@@ -103,7 +106,7 @@ RPC_IMPL(mod_replace_stream_t, ReplaceOffer, req, z, response)
 	stream_addr.getaddr((sockaddr*)addrbuf);
 
 	using namespace mp::placeholders;
-	m_stream_core->connect(
+	m_stream_core_c->connect(
 			PF_INET, SOCK_STREAM, 0,
 			(sockaddr*)addrbuf, sizeof(addrbuf),
 			net->connect_timeout_msec(),
@@ -467,7 +470,7 @@ try {
 
 	mp::set_nonblock(fd);
 
-	m_stream_core->add<stream_handler>(fd);
+	m_stream_core_c->add<stream_handler>(fd);
 	fdscope.release();
 
 } catch (std::exception& e) {


### PR DESCRIPTION
kumo-server に -M を指定した状態で kumoctl full-replace すると Copying のままになってしまう現象が発生します。
accept() と connect() が同時に発生すると stream_connected() が呼ばれないようです。
kumoctl full-replace 時は自ノードに対しても replace を行うため、connect() と accept() がほぼ同時に行われるため発生しやすいようです。

ですが、理屈上は他ノードとの通信においても、accept() と connect() が同時に行われると同じ現象が発生すると思われます。

m_stream_core を connect用と accept用にわけることで回避できたみたいです。
