### PR TITLE
kumo-gateway is killed by SIGHUP when -E option was specified

### DIFF
--- a/src/logic/gateway/main.cc
+++ b/src/logic/gateway/main.cc
@@ -200,12 +200,12 @@ int main(int argc, char* argv[])
 
 	// run server
 	gateway::init(arg);
+	gateway::net->run(arg);
 
 	if(mctext.get()) { mctext->run(); }
 	if(mcbin.get())  { mcbin->run();  }
 	if(cloudy.get()) { cloudy->run(); }
 
-	gateway::net->run(arg);
 	gateway::net->join();
 }
 


### PR DESCRIPTION
I think it's caused by a timer thread which is created before setting signal handlers.

I wrote a workaround, but I don't know if it's a suitable fix.
