### PR TITLE
Increase the maximum size of a value for binary protocol.

### DIFF
--- a/src/gate/cloudy.cc
+++ b/src/gate/cloudy.cc
@@ -146,7 +146,7 @@ void send_response(
 		entry* e, auto_zone z,
 		uint8_t status,
 		const char* key, uint16_t keylen,
-		const void* val, uint16_t vallen,
+		const void* val, uint32_t vallen,
 		const char* extra, uint16_t extralen,
 		uint64_t cas)
 {

--- a/src/gate/memcache_binary.cc
+++ b/src/gate/memcache_binary.cc
@@ -188,7 +188,7 @@ private:
 	static void send_response(entry* e, auto_zone z,
 			uint8_t status,
 			const char* key, uint16_t keylen,
-			const void* val, uint16_t vallen,
+			const void* val, uint32_t vallen,
 			const char* extra, uint16_t extralen,
 			uint64_t cas);
 
@@ -377,7 +377,7 @@ void handler::send_response(
 		entry* e, auto_zone z,
 		uint8_t status,
 		const char* key, uint16_t keylen,
-		const void* val, uint16_t vallen,
+		const void* val, uint32_t vallen,
 		const char* extra, uint16_t extralen,
 		uint64_t cas)
 {


### PR DESCRIPTION
Value length should be stored in uint32_t, instead of uint16_t.
