### PR TITLE
add remove-server command for kumoctl

### DIFF
--- a/src/command/kumoctl
+++ b/src/command/kumoctl
@@ -190,6 +190,10 @@ class KumoRPC
 		send_request_sync_ex(Protocol::StartReplace, [])
 	end
 
+	def RemoveServer(serverAddr)
+		send_request_sync_ex(Protocol::RemoveServer, [serverAddr])
+	end
+
 	module Protocol
 		GetNodesInfo        = 0 << 16 |  99
 		AttachNewServers    = 0 << 16 | 100
@@ -199,6 +203,7 @@ class KumoRPC
 		StartReplace        = 0 << 16 | 104
 		GetStatus           = 0 << 16 |  97
 		SetConfig           = 0 << 16 |  98
+		RemoveServer        = 0 << 16 | 200
 	end
 
 	MANAGER_DEFAULT_PORT = 19700
@@ -318,6 +323,10 @@ class KumoManager < KumoRPC
 			send_request_sync_ex(Protocol::StartReplace, [])
 		end
 	end
+
+	def RemoveServer(serverAddr)
+		send_request_sync_ex(Protocol::RemoveServer, [serverAddr])
+	end
 end
 
 if $0 == __FILE__
@@ -339,6 +348,7 @@ def usage
 	puts "   backup  [suffix=#{$now }]  create backup with specified suffix"
 	puts "   enable-auto-replace        enable auto replace"
 	puts "   disable-auto-replace       disable auto replace"
+	puts "   remove-server address[:port=#{KumoRPC::SERVER_DEFAULT_PORT}] remove server with specified server address"
 	exit 1
 end
 
@@ -410,6 +420,13 @@ when "replace"
 when "full-replace"
 	usage if ARGV.length != 0
 	p KumoManager.new(host, port).StartReplace(true)
+
+when "remove-server"
+	usage if ARGV.length != 1
+	serverHost, serverPort = (ARGV.shift).split(':', 2)
+	serverPort ||= KumoRPC::SERVER_DEFAULT_PORT
+	puts "serverAddress=#{serverHost}:#{serverPort}"
+	p KumoManager.new(host, port).RemoveServer("#{serverHost}:#{serverPort}")
 
 else
 	puts "unknown command #{cmd}"

--- a/src/logic/manager.proto.h
+++ b/src/logic/manager.proto.h
@@ -40,6 +40,7 @@ namespace manager {
 @message mod_control_t::CreateBackup        = 102
 @message mod_control_t::SetAutoReplace      = 103
 @message mod_control_t::StartReplace        = 104
+@message mod_control_t::RemoveServer        = 200
 
 
 @rpc mod_network_t
@@ -179,6 +180,9 @@ private:
 		bool full = false;
 	};
 
+	message RemoveServer {
+		std::string serverAddr;
+	};
 
 public:
 	mod_control_t();

--- a/src/logic/manager/framework.cc
+++ b/src/logic/manager/framework.cc
@@ -100,9 +100,21 @@ void framework::lost_node(address addr, role_type id)
 		return;
 
 	} else if(id == ROLE_SERVER) {
-		// FIXME delayed change
-		mod_replace.remove_server(addr);
-		return;
+		bool w_active = share->whs().server_is_active(addr);
+		bool r_active = share->rhs().server_is_active(addr);
+		LOG_TRACE("active hash space: w=",w_active,", r=",r_active);
+		if(w_active || r_active)
+		{
+			// FIXME delayed change
+			LOG_WARN("remove server: server=",addr);
+			mod_replace.remove_server(addr);
+			return;
+		}
+		else
+		{
+			LOG_WARN("already removed: server=",addr);
+			return;
+		}
 	}
 }
 

--- a/src/logic/manager/framework.cc
+++ b/src/logic/manager/framework.cc
@@ -57,6 +57,7 @@ try {
 	RPC_DISPATCH(mod_control, CreateBackup);
 	RPC_DISPATCH(mod_control, SetAutoReplace);
 	RPC_DISPATCH(mod_control, StartReplace);
+	RPC_DISPATCH(mod_control, RemoveServer);
 	default:
 		throw unknown_method_error();
 	}
@@ -94,7 +95,7 @@ void framework::new_node(address addr, role_type id, shared_node n)
 
 void framework::lost_node(address addr, role_type id)
 {
-	LOG_WARN("lost node ",id," ",addr);
+	LOG_WARN("lost node, tpye=",(uint16_t)id,", addr=",addr);
 	if(id == ROLE_MANAGER) {
 		return;
 


### PR DESCRIPTION
kumoctl remove-server command deletes the server specified from the w/r hash space. 

If kumo-server is stopped, it will be automatically detected by kumo-manager and will be removed from a hash space. 
However, it consumes for 1 to 3 seconds until it is reflected, and set request to the stopped server cannot answer in the meantime. 

In order to stop a kumo-server safely, you should delete from a hash space beforehand using a kumoctl remove-server command. 
