### PR TITLE
fixes deadlock problem on kumo-server

### DIFF
--- a/src/logic/server/mod_control.cc
+++ b/src/logic/server/mod_control.cc
@@ -131,8 +131,8 @@ RPC_IMPL(mod_control_t, GetStatus, req, z, response)
 			bool active;
 			bool hssame;
 			{
-				pthread_scoped_rdlock rhlk(share->rhs_mutex());
 				pthread_scoped_rdlock whlk(share->whs_mutex());
+				pthread_scoped_rdlock rhlk(share->rhs_mutex());
 				if(share->rhs() == share->whs()) {
 					hssame = true;
 				} else {


### PR DESCRIPTION
a deadlock may occur when you use 'kumostat replstat' or 'kumotop' command.
