### PR TITLE
fix --key-prefix option on kumo-gateway

### DIFF
--- a/src/logic/gateway/main.cc
+++ b/src/logic/gateway/main.cc
@@ -121,7 +121,7 @@ struct arg_t : rpc_args {
 				type::boolean(&async_replicate_set));
 		on("-Ad", "--async-replicate-delete",
 				type::boolean(&async_replicate_delete));
-		on("-k", "--key-prefix",
+		on("-kp", "--key-prefix",
 				type::string(&key_prefix, ""));
 		parse(argc, argv);
 	}
@@ -162,7 +162,7 @@ struct arg_t : rpc_args {
 			"--delete-retry           delete retry limit\n"
 		"  -rn <number="<<renew_threshold<<">    "
 			"--renew-threshold        hash space renew threshold\n"
-		"  -k <string>       "
+		"  -kp <string>       "
 			"--key-prefix             add prefix to keys automatically\n"
 		;
 		rpc_args::show_usage();


### PR DESCRIPTION
duplication in the --keepalive-interval option
