### PR TITLE
fix kumo-server status

### DIFF
--- a/src/logic/server.proto.h
+++ b/src/logic/server.proto.h
@@ -211,6 +211,7 @@ private:
 		void push_returned(ClockTime ct);
 		const address& mgr_addr() const;
 		bool is_finished(ClockTime ct) const;
+		bool is_waiting() const { return m_push_waiting > 0; }
 		void invalidate();
 	private:
 		int m_push_waiting;
@@ -247,6 +248,7 @@ public:
 	void replace_offer_pop(ClockTime replace_time, REQUIRE_STLK);
 	mp::pthread_mutex& state_mutex() { return m_state_mutex; }
 
+	bool is_waiting()  const { return m_state.is_waiting(); }
 	bool is_copying()  const { return m_copying; }
 	bool is_deleting() const { return m_deleting; }
 @end

--- a/src/logic/server/mod_control.cc
+++ b/src/logic/server/mod_control.cc
@@ -145,12 +145,13 @@ RPC_IMPL(mod_control_t, GetStatus, req, z, response)
 				}
 			}
 
+			bool waiting = net->mod_replace.is_waiting();
 			bool copying = net->mod_replace.is_copying();
 			bool deleting = net->mod_replace.is_deleting();
 
 			uint32_t flags = 0;
 			if(!active)  { flags |= 0x01; }
-			if(!hssame)  { flags |= 0x02; }
+			if(!hssame)  { flags |= waiting ? 0x04 : 0x02; }
 			if(copying)  { flags |= 0x04; }
 			if(deleting) { flags |= 0x08; }
 


### PR DESCRIPTION
kumo-server にて、replace-copy 処理中にステータスが copying から wait になってしまう問題を修正
